### PR TITLE
Update README.md to use correct GitHub Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-There is good documentation available at http://tumblr.github.com/collins. The
+There is good documentation available at https://tumblr.github.io/collins. The
 documentation below is for developers or people setting up a new instance.
 
-The most recent release of collins is available [here](http://tumblr.github.com/collins/downloads.html)
+The most recent release of collins is available [here](https://tumblr.github.io/collins/downloads.html)
 
 [![Build Status](https://travis-ci.org/tumblr/collins.png?branch=master)](https://travis-ci.org/tumblr/collins)
 [![Dependency Status](https://www.versioneye.com/user/projects/555e7598393564000d040000/badge.svg?style=flat)](https://www.versioneye.com/user/projects/555e7598393564000d040000)
@@ -13,11 +13,11 @@ The most recent release of collins is available [here](http://tumblr.github.com/
 
 ## Quickstart
 
-[Docker](http://tumblr.github.com/collins/#quickstart-docker)
+[Docker](https://tumblr.github.io/collins/#quickstart-docker)
 
-[Use a Zip](http://tumblr.github.com/collins/#quickstart-zip)
+[Use a Zip](https://tumblr.github.io/collins/#quickstart-zip)
 
-[Build from Source](http://tumblr.github.com/collins/#quickstart-source)
+[Build from Source](https://tumblr.github.io/collins/#quickstart-source)
 
 ## Docker Image
 


### PR DESCRIPTION
Super small README change to update links from http://tumblr.github.com to the new GitHub Pages URL of https://tumblr.github.io. http://tumblr.github.com already redirects to https://tumblr.github.io so the links might as well be updated.
